### PR TITLE
Update nginx.conf

### DIFF
--- a/app/nginx/nginx.conf
+++ b/app/nginx/nginx.conf
@@ -102,7 +102,7 @@ http {
         }
 
         location /v2/ {
-             proxy_pass          http://ta:5100/;
+             proxy_pass          http://ta:5100;
         }
 
 


### PR DESCRIPTION
proxy_pass http://ta:5100/;という設定の場合、5000/v2/1/openapi.jsonへの接続を誤ったパスであるhttp://ta:5100/1/openapi.jsonに転送するため、正しく転送される設定に修正した。