### PR TITLE
Update コンテナ構築・辞書データロード手順.txt

### DIFF
--- a/app/コンテナ構築・辞書データロード手順.txt
+++ b/app/コンテナ構築・辞書データロード手順.txt
@@ -69,7 +69,7 @@
 　　以下のコマンドを実行する
 　　docker-compose build
     
-　　注)docker for Windowsを利用する場合は、FILE SHARINGの設定を行う必要がある。
+　　注)Windows版、macOS版のDocker Desktopを利用する場合は、FILE SHARINGの設定を行う必要がある。
 　　　　DockerのSettings画面からResources > FILE SHARINGを開き、
     　　ホスト側のディレクトリ、ファイルパスを登録する。
      


### PR DESCRIPTION
Windows版、macOS版ともにDockerでFILE SHARINGの設定が必要なことを記載した。