### PR TITLE
辞書ローダーで、既存インデックスがある場合に一度削除してからデータを入れなおす処理を追加

### DIFF
--- a/app/load_tool/bin/pipeline_available_load_dict4es_ta.py
+++ b/app/load_tool/bin/pipeline_available_load_dict4es_ta.py
@@ -245,4 +245,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     connector = TsvElasticsearchConnector("localhost:9200", args.index)
+    # 引数として渡されたインデックスをElasticsearch上から削除する
+    connector.es_client.indices.delete(index=args.index, ignore=[400, 404])
+    # データを新規登録／再登録する
     connector.throw_tsv(args.file)


### PR DESCRIPTION
辞書を更新した際の、既存データ削除処理を追加致しました。
マージよろしくお願い致します。