### PR TITLE
クエリのひな形ファイルがリポジトリ全体の .gitignore の影響で不足していたので追加

### DIFF
--- a/ReconciliationServiceAPI/src/es/query.json
+++ b/ReconciliationServiceAPI/src/es/query.json
@@ -1,0 +1,175 @@
+{
+    "query": {
+        "bool": {
+            "must": [
+                {
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "term": {
+                                                "query_type": "term_before"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "normalized_name.term": {
+                                                    "query": ""
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "term": {
+                                                "query_type": "term_after"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "normalized_name.term": {
+                                                    "query": ""
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "term": {
+                                                "query_type": "mlt_before"
+                                            }
+                                        },
+                                        {
+                                            "more_like_this": {
+                                                "fields": [
+                                                    "normalized_name.mlt"
+                                                ],
+                                                "like": "",
+                                                "max_query_terms": 100,
+                                                "minimum_should_match": "30%",
+                                                "min_term_freq": 0,
+                                                "min_word_length": 0,
+                                                "max_word_length": 0
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "term": {
+                                                "query_type": "mlt_after"
+                                            }
+                                        },
+                                        {
+                                            "more_like_this": {
+                                                "fields": [
+                                                    "normalized_name.mlt"
+                                                ],
+                                                "like": "",
+                                                "max_query_terms": 100,
+                                                "minimum_should_match": "30%",
+                                                "min_term_freq": 0,
+                                                "min_word_length": 0,
+                                                "max_word_length": 0
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "should": [
+                {
+                    "multi_match": {
+                        "query": "1",
+                        "type": "most_fields",
+                        "fields": [
+                            "guideline_PN001",
+                            "guideline_PN002",
+                            "guideline_PN003",
+                            "guideline_PN004",
+                            "guideline_PN005",
+                            "guideline_PN006",
+                            "guideline_PN007",
+                            "guideline_PN011",
+                            "guideline_PN012",
+                            "guideline_PN013",
+                            "guideline_PN014",
+                            "guideline_PN015",
+                            "guideline_PN016",
+                            "guideline_PN017",
+                            "guideline_PN018",
+                            "guideline_PN019",
+                            "guideline_PN020",
+                            "guideline_PN021",
+                            "guideline_PN022",
+                            "guideline_PN024",
+                            "guideline_PN026",
+                            "guideline_PN027",
+                            "guideline_PN028",
+                            "guideline_PN029",
+                            "guideline_PN030",
+                            "guideline_PN034",
+                            "guideline_PN036",
+                            "guideline_PN037",
+                            "guideline_PN038",
+                            "guideline_PN039",
+                            "guideline_PN041",
+                            "guideline_PN042",
+                            "guideline_PN043",
+                            "guideline_PN047",
+                            "guideline_PN048",
+                            "guideline_PN049",
+                            "guideline_PN050",
+                            "guideline_PN051"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "profile": "false",
+    "size": 0,
+    "aggs": {
+        "tags": {
+            "terms": {
+                "field": "query_type",
+                "size": 4
+            },
+            "aggs": {
+                "top_tag_hits": {
+                    "top_hits": {
+                        "size": 15,
+                        "sort": [
+                            {
+                                "_score": {
+                                    "order": "desc"
+                                }
+                            },
+                            {
+                                "normalized_name": {
+                                    "order": "asc"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
表題の通り、クエリのひな形ファイルがリポジトリ全体の .gitignore の影響でコミットされず、不足していたので追加しました。よろしくお願いいたします。